### PR TITLE
childPromiseLinkedList:  Implemented a linked list-like functionality using optional child promises.

### DIFF
--- a/ConcurrencyTests/PromiseTests.swift
+++ b/ConcurrencyTests/PromiseTests.swift
@@ -56,6 +56,8 @@ class PromiseTests: QuickSpec {
                 successValue = nil
                 errorValue = nil
                 
+                subject = Promise<Int>()
+                
                 subject.future.then({ (value) in
                     primaryTimestamp = Date()
                     successValue = value
@@ -113,7 +115,7 @@ class PromiseTests: QuickSpec {
                     expect(secondarySuccessValue).toEventually(equal("5"))
                     expect(secondaryTimeStamp?.isAfter(primaryTimestamp!)).toEventually(beTrue())
                     expect(tertiarySuccessValue).toEventually(equal(5))
-                    expect(tertiaryTimeStamp?.isAfter(secondaryTimeStamp!)).toEventually(beTrue())
+                    expect(tertiaryTimeStamp?.isAfter(secondaryTimeStamp)).toEventually(beTrue())
                 }
                 
             }
@@ -152,7 +154,7 @@ class PromiseTests: QuickSpec {
             }
         }
         
-        describe("flat-mapping") {
+        describe("mapping") {
             var future: Future<Int>!
             var mappedFuture: Future<String>!
             
@@ -164,7 +166,7 @@ class PromiseTests: QuickSpec {
             context("when the map block results in nil") {
                 beforeEach {
                     subject.resolve(3)
-                    mappedFuture = future.flatMap({ (intValue) -> (String?) in
+                    mappedFuture = future.map({ (intValue) -> (String?) in
                         return nil
                     })
                 }
@@ -180,7 +182,7 @@ class PromiseTests: QuickSpec {
             
             context("when the map block results in non-nil") {
                 beforeEach {
-                    mappedFuture = future.flatMap({ (intValue) -> (String?) in
+                    mappedFuture = future.map({ (intValue) -> (String?) in
                         return "\(intValue)"
                     })
                 }

--- a/ConcurrencyTests/TestHelpers.swift
+++ b/ConcurrencyTests/TestHelpers.swift
@@ -17,7 +17,10 @@ func item<T>(_ item: Any?, isA: T.Type, and evalBlock:(T)->(Bool)) -> Bool {
 
 
 extension Date {
-    func isAfter(_ otherDate: Date) -> Bool {
+    func isAfter(_ otherDate: Date?) -> Bool {
+        guard let otherDate = otherDate else {
+            return false
+        }
         return timeIntervalSince(otherDate) > 0
     }
 }

--- a/Source/PeriodicFetcher.swift
+++ b/Source/PeriodicFetcher.swift
@@ -34,6 +34,7 @@ class PeriodicFetcher<T:Equatable> {
     
     private var variable: Variable<StreamState<T>> = Variable(.noData)
     private var timer: Timer?
+    private let operationQueue = OperationQueue()
     fileprivate let disposeBag = DisposeBag()
     
     private var timeIntervalIsCurrent: Bool {
@@ -121,9 +122,13 @@ class PeriodicFetcher<T:Equatable> {
         }
         
         currentFuture = getFuture().then { [weak self](value) in
-            self?.emitIfPossible(.newData(value))
+            self?.operationQueue.addOperation { [weak self] in
+                self?.emitIfPossible(.newData(value))
+            }
         }.error { [weak self](errorFromFuture) in
-            self?.emitIfPossible(.error(errorFromFuture))
+            self?.operationQueue.addOperation { [weak self] in
+                self?.emitIfPossible(.error(errorFromFuture))
+            }
         }
     }
     

--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -76,35 +76,35 @@ class Future<T> {
         }
         return self
     }
-    
+
     //MARK: - PRIVATE
-    
+
     fileprivate func resolve(_ val: T) {
         operationQueue.addOperation {
             if self.isComplete {
                 return
             }
-            
+
             self.value = val
-            
+
             self.thenBlock?(val)
             self.childFuture?.resolve(val)
         }
     }
-    
+
     fileprivate func reject(_ err: Error) {
         operationQueue.addOperation {
             if self.isComplete {
                 return
             }
-            
+
             self.error = err
-            
+
             self.errorBlock?(err)
             self.childFuture?.reject(err)
         }
     }
-    
+
     private func appendChild() -> Future<T> {
         if let child = childFuture {
             return child.appendChild()

--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -7,53 +7,52 @@ import Foundation
 
 
 class Promise<T> {
-    
+
     let future = Future<T>()
-    
+
     func resolve(_ val: T) {
         future.resolve(val)
     }
-    
+
     func reject(_ err: Error) {
         future.reject(err)
     }
-    
+
 }
 
 class Future<T> {
     typealias ThenBlock  = (T)->()
     typealias ErrorBlock = (Error)->()
-    
+
     private var thenBlock: ThenBlock?
     private var errorBlock: ErrorBlock?
     private var childFuture: Future?
-    
+
     private let operationQueue = OperationQueue()
-    
+
     //MARK: - PUBLIC -
-    
+
     private(set) var value: T?
     private(set) var error: Error?
-    
+
     public var succeeded: Bool {
         return value != nil
     }
-    
+
     public var failed: Bool {
         return error != nil
     }
-    
+
     public var isComplete: Bool {
         return succeeded || failed
     }
-    
+
     @discardableResult public func then(_ callback: @escaping ThenBlock) -> Future<T> {
         operationQueue.addOperation {
             if let value = self.value { //If the future has already been resolved with a value. Call the block immediately.
                 callback(value)
             }
-            
-            if self.thenBlock == nil {
+            else if self.thenBlock == nil {
                 self.thenBlock = callback
             }
             else {
@@ -62,14 +61,13 @@ class Future<T> {
         }
         return self
     }
-    
+
     @discardableResult public func error(_ callback: @escaping ErrorBlock) -> Future<T> {
         operationQueue.addOperation {
             if let error = self.error { //If the future has already been rejected with an error. Call the block immediately.
                 callback(error)
             }
-            
-            if self.errorBlock == nil {
+            else if self.errorBlock == nil {
                 self.errorBlock = callback
             }
             else {

--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -26,6 +26,7 @@ class Future<T> {
     
     private var thenBlock: ThenBlock?
     private var errorBlock: ErrorBlock?
+    private var childFuture: Future?
     
     private let operationQueue = OperationQueue()
     
@@ -34,39 +35,51 @@ class Future<T> {
     private(set) var value: T?
     private(set) var error: Error?
     
-    var succeeded: Bool {
+    public var succeeded: Bool {
         return value != nil
     }
     
-    var failed: Bool {
+    public var failed: Bool {
         return error != nil
     }
     
-    var isComplete: Bool {
+    public var isComplete: Bool {
         return succeeded || failed
     }
     
-    @discardableResult func then(_ callback: @escaping ThenBlock) -> Future<T> {
+    @discardableResult public func then(_ callback: @escaping ThenBlock) -> Future<T> {
         operationQueue.addOperation {
             if let value = self.value { //If the future has already been resolved with a value. Call the block immediately.
                 callback(value)
             }
             
-            self.thenBlock = callback
+            if self.thenBlock == nil {
+                self.thenBlock = callback
+            }
+            else {
+                self.appendChild().then(callback)
+            }
         }
         return self
     }
     
-    @discardableResult func error(_ callback: @escaping ErrorBlock) -> Future<T> {
+    @discardableResult public func error(_ callback: @escaping ErrorBlock) -> Future<T> {
         operationQueue.addOperation {
             if let error = self.error { //If the future has already been rejected with an error. Call the block immediately.
                 callback(error)
             }
             
-            self.errorBlock = callback
+            if self.errorBlock == nil {
+                self.errorBlock = callback
+            }
+            else {
+                self.appendChild().error(callback)
+            }
         }
         return self
     }
+    
+    //MARK: - PRIVATE
     
     fileprivate func resolve(_ val: T) {
         operationQueue.addOperation {
@@ -77,6 +90,7 @@ class Future<T> {
             self.value = val
             
             self.thenBlock?(val)
+            self.childFuture?.resolve(val)
         }
     }
     
@@ -89,6 +103,16 @@ class Future<T> {
             self.error = err
             
             self.errorBlock?(err)
+            self.childFuture?.reject(err)
         }
+    }
+    
+    private func appendChild() -> Future<T> {
+        if let child = childFuture {
+            return child.appendChild()
+        }
+        let future = Future<T>()
+        childFuture = future
+        return future
     }
 }

--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -48,31 +48,27 @@ class Future<T> {
     }
 
     @discardableResult public func then(_ callback: @escaping ThenBlock) -> Future<T> {
-        operationQueue.addOperation {
-            if let value = self.value { //If the future has already been resolved with a value. Call the block immediately.
-                callback(value)
-            }
-            else if self.thenBlock == nil {
-                self.thenBlock = callback
-            }
-            else {
-                self.appendChild().then(callback)
-            }
+        if let value = self.value { //If the future has already been resolved with a value. Call the block immediately.
+            callback(value)
+        }
+        else if self.thenBlock == nil {
+            self.thenBlock = callback
+        }
+        else {
+            self.appendChild().then(callback)
         }
         return self
     }
 
     @discardableResult public func error(_ callback: @escaping ErrorBlock) -> Future<T> {
-        operationQueue.addOperation {
-            if let error = self.error { //If the future has already been rejected with an error. Call the block immediately.
-                callback(error)
-            }
-            else if self.errorBlock == nil {
-                self.errorBlock = callback
-            }
-            else {
-                self.appendChild().error(callback)
-            }
+        if let error = self.error { //If the future has already been rejected with an error. Call the block immediately.
+            callback(error)
+        }
+        else if self.errorBlock == nil {
+            self.errorBlock = callback
+        }
+        else {
+            self.appendChild().error(callback)
         }
         return self
     }
@@ -80,27 +76,31 @@ class Future<T> {
     //MARK: - PRIVATE
 
     fileprivate func resolve(_ val: T) {
+        if self.isComplete {
+            return
+        }
+        
+        self.value = val
+        
         operationQueue.addOperation {
-            if self.isComplete {
-                return
-            }
-
-            self.value = val
-
             self.thenBlock?(val)
+        }
+        operationQueue.addOperation {
             self.childFuture?.resolve(val)
         }
     }
 
     fileprivate func reject(_ err: Error) {
+        if self.isComplete {
+            return
+        }
+        
+        self.error = err
+        
         operationQueue.addOperation {
-            if self.isComplete {
-                return
-            }
-
-            self.error = err
-
             self.errorBlock?(err)
+        }
+        operationQueue.addOperation {
             self.childFuture?.reject(err)
         }
     }
@@ -109,9 +109,11 @@ class Future<T> {
         if let child = childFuture {
             return child.appendChild()
         }
-        let future = Future<T>()
-        childFuture = future
-        return future
+        else {
+            let future = Future<T>()
+            childFuture = future
+            return future
+        }
     }
 }
 
@@ -129,7 +131,7 @@ extension Future {
         return future
     }
     
-    public func flatMap<Q>(_ block:@escaping (T)->(Q?)) -> Future<Q> {
+    public func map<Q>(_ block:@escaping (T)->(Q?)) -> Future<Q> {
         let promise = Promise<Q>()
         
         then { (value) in


### PR DESCRIPTION
- This allows multiple then blocks to be executed by each additional one past the first being put into a child promise and appended to the end of the list.
- Also added explicit access-level notation to all methods and properties.