### PR TITLE
joinedFutures: Added joined future functionality.

### DIFF
--- a/ConcurrencyTests/TestHelpers.swift
+++ b/ConcurrencyTests/TestHelpers.swift
@@ -16,6 +16,14 @@ func item<T>(_ item: Any?, isA: T.Type, and evalBlock:(T)->(Bool)) -> Bool {
 }
 
 
+extension Error {
+    func equals(_ nsError: NSError) -> Bool {
+        let selfAsNSError = self as NSError
+        return selfAsNSError == nsError
+    }
+}
+
+
 extension Date {
     func isAfter(_ otherDate: Date?) -> Bool {
         guard let otherDate = otherDate else {


### PR DESCRIPTION
- Created a fileprivate JoinedFuture type, which has a master Future which only completes when each in a given array of Futures completes.
- Added a class method on Future which takes in an array of Futures and returns the master future of a JoinedFuture. This maintains the simple interface of Future while giving the consume some extended functionality.