### PR TITLE
Incremented version number(s).

### DIFF
--- a/Concurrency.podspec
+++ b/Concurrency.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Concurrency'
-  s.version          = '0.1.0'
+  s.version          = '1.0.0'
   s.summary          = 'A small toolkit for handling concurrency in Swift.'
 
   s.description      = <<-DESC

--- a/Concurrency/Info.plist
+++ b/Concurrency/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ goCallYourMother().then { (earful) in
 
 As you can see, much like the `onSuccess(_:)` and `onError(_:)` methods on [`Result`](#result), these return discardable references to the promise and can thus be chained and used together or independently of one another.
 
+__Side note:__ There's also a handy `finally(_:)` method as well, which will add a block to be executed after completion, regardless of success or failure. It executes after the given success or failure block.
+
 The real magic about Future is that `then(_:)` and `error(_:)` can be called as many times as needed, and each of the actions will execute in order. So, if you have a method which fetches a value and returns a promise, and there are multiple layers of the app that need to be updated with that value, you can pass that future along from method to method, tacking on success actions as you go.
 
 Yes, I know, an example is in order. So, let's say we have that same method from earlier: `func goCallYourMother() -> Future<AnEarful>`. We could propagate it along like so:


### PR DESCRIPTION
New Features:
- Infinite `then` and `error` blocks. Utilizes a child future / linked list pattern.
- Joined futures. Call class method `joining` and pass in an array of Future<T> objects, and get a single Future<[T]> which will complete when all have succeeded or any have failed.
- Added similar syntactic sugar to StreamState as exists on Result: `.onNew(_:)` and `.onError(_:)`
- Added handy, static `preResolved(value:)` and `preRejected(error:)` methods for synchronous/immediate futures.
- Added `.map(_:)` method to Future for translating from one future to another.
- Added `finally(_:)` block to future that executes on either type of completion.
- Improved performance and thread safety.
- Future now uses a single `Result<T>?` under the hood instead of two separate optionals (`T?` and `Error?`)