### PR TITLE
thenFuture: Added method for triggering a new future on the completion of another.

### DIFF
--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -202,6 +202,23 @@ public extension Future {
     public class func joining(_ futures:[Future<T>]) -> Future<[T]> {
         return JoinedFuture(futures).future
     }
+    
+    public func thenFuture<Q>(_ futureBlock:@escaping (T)->(Future<Q>)) -> Future<Q> {
+        let promise = Promise<Q>()
+        
+        self.then { (firstValue) in
+            futureBlock(firstValue).then({ (secondValue) in
+                promise.resolve(secondValue)
+            }).error({ (secondError) in
+                promise.reject(secondError)
+            })
+        }
+        self.error { (firstError) in
+            promise.reject(firstError)
+        }
+        
+        return promise.future
+    }
 
 }
 


### PR DESCRIPTION
If you have a Future of type `<T>` and on its completion, you want it to trigger a future of type `<Q>` that depends on the success of the first future, you can now call:
```Swift
let qFutureAfterTFuture = tFuture.thenFuture{ (tVal) -> Future<Q> in
  return someQFutureMethod(t: tVal)
}
```