### PR TITLE
Removed the requirement for T on StreamState to be equatable.

### DIFF
--- a/Concurrency.podspec
+++ b/Concurrency.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Concurrency'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'A small toolkit for handling concurrency in Swift.'
 
   s.description      = <<-DESC
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
 
   s.platform              = :ios, "10.0"
   s.ios.deployment_target = '10.0'
-  # s.compiler_flags = 'SWIFT_VERSION', '3.2'
 
   s.source_files = 'Source/*'
   s.dependency 'RxSwift' #, '~> 3.5'

--- a/Concurrency/Info.plist
+++ b/Concurrency/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ConcurrencyTests/PeriodicFetcherTests.swift
+++ b/ConcurrencyTests/PeriodicFetcherTests.swift
@@ -71,7 +71,7 @@ class PeriodicFetcherTests: QuickSpec {
             it("should begin in the non-fetching state") {
                 expect(subject.isFetching).to(equal(false))
                 expect(streamStates.count).to(equal(1))
-                expect(streamStates.first).to(equal(.noData))
+                expect(streamStates.first == .noData).to(beTrue())
             }
             
             describe("fetching once (without periodic fetching)") {
@@ -82,8 +82,8 @@ class PeriodicFetcherTests: QuickSpec {
                 
                 it("should only fetch once (plus initial .noData)") {
                     expect(streamStates.count).toEventually(equal(2))
-                    expect(streamStates.first).to(equal(StreamState.noData))
-                    expect(streamStates.last).to(equal(StreamState.newData(0)))
+                    expect(streamStates.first == .noData).to(beTrue())
+                    expect(streamStates.last == .newData(0)).to(beTrue())
                     expect(showsIsFetching).to(equal(false))
                 }
             }
@@ -128,7 +128,7 @@ class PeriodicFetcherTests: QuickSpec {
                     it("should stop emitting data after being told to stop fetching") {
                         expect(streamStates.count).toEventually(equal(1))
                         expect(streamStates.count).toNotEventually(equal(2))
-                        expect(streamStates.last).to(equal(StreamState.noData))
+                        expect(streamStates.last == .noData).to(beTrue())
                         expect(subject.isFetching).to(equal(false))
                     }
                 }
@@ -155,7 +155,7 @@ class PeriodicFetcherTests: QuickSpec {
                     it("should stop emitting data after being told to stop fetching") {
                         expect(streamStates.count).toEventually(equal(3))
                         expect(streamStates.count).toNotEventually(equal(4))
-                        expect(streamStates.last).toEventually(equal(StreamState.newData(2)))
+                        expect(streamStates.last == .newData(2)).toEventually(beTrue())
                         expect(subject.isFetching).toEventually(equal(false))
                     }
                 }

--- a/Source/PeriodicFetcher.swift
+++ b/Source/PeriodicFetcher.swift
@@ -7,21 +7,10 @@ import Foundation
 import RxSwift
 
 
-public enum StreamState<T:Equatable>: Equatable {
+public enum StreamState<T> {
     case noData
     case newData(T)
     case error(Error)
-    
-    public static func ==(lhs: StreamState, rhs: StreamState) -> Bool {
-        switch (lhs, rhs) {
-        case (.newData(let data1), .newData(let data2)):
-            return data1 == data2
-        case (.error(_), .error(_)), (.noData, .noData):
-            return true
-        default:
-            return false
-        }
-    }
     
     @discardableResult public func onError(_ errorBlock: (Error)->()) -> StreamState<T> {
         switch self {
@@ -45,7 +34,34 @@ public enum StreamState<T:Equatable>: Equatable {
     
 }
 
-public class PeriodicFetcher<T:Equatable> {
+public extension StreamState where T: Equatable {
+    public static func ==(lhs: StreamState, rhs: StreamState) -> Bool {
+        switch (lhs, rhs) {
+        case (.noData, .noData), (.error(_), .error(_)):
+            return true
+        case (.newData(let value1), .newData(let value2)):
+            return value1 == value2
+        default:
+            return false
+        }
+    }
+    
+    public static func ==(lhs: StreamState<T>?, rhs: StreamState<T>) -> Bool {
+        guard let lhs = lhs else {
+            return false
+        }
+        return lhs == rhs
+    }
+    
+    public static func ==(lhs: StreamState<T>, rhs: StreamState<T>?) -> Bool {
+        guard let rhs = rhs else {
+            return false
+        }
+        return lhs == rhs
+    }
+}
+
+public class PeriodicFetcher<T> {
     
     public typealias FutureGenerator = ()->(Future<T>)
     public typealias TimeIntervalGenerator = ()->(Double)


### PR DESCRIPTION
- Added equatable methods (that allow for optionals) to a `T:Equatable` extension, but Swift 4 does not allow for conditional conformance, so it will not appear to conform to Equatable despite the fact that it does.